### PR TITLE
QICoreCommon Initial

### DIFF
--- a/input/cql/QICoreCommon.cql
+++ b/input/cql/QICoreCommon.cql
@@ -1,0 +1,351 @@
+/*
+@author: Stan Rankins
+@description: Common terminologies and functions used in QI-Core-based CQL artifacts
+@update: Based on FHIRCommon Version 4.0.012 for use in ecqm-content-qicore-2022 repos
+*/
+library QICoreCommon version '1.0.000'
+
+using QICore version '4.1.1'
+
+include FHIRHelpers version '4.0.012'
+
+codesystem "LOINC": 'http://loinc.org'
+codesystem "SNOMEDCT": 'http://snomed.info/sct'
+codesystem "ICD10CM": 'http://hl7.org/fhir/sid/icd-10-cm'
+codesystem "RoleCode": 'http://terminology.hl7.org/CodeSystem/v3-RoleCode'
+codesystem "Diagnosis Role": 'http://terminology.hl7.org/CodeSystem/diagnosis-role'
+codesystem "RequestIntent": 'http://terminology.hl7.org/CodeSystem/request-intent'
+codesystem "MedicationRequestCategory": 'http://terminology.hl7.org/CodeSystem/medicationrequest-category'
+codesystem "ConditionClinicalStatusCodes": 'http://terminology.hl7.org/CodeSystem/condition-clinical'
+codesystem "ConditionVerificationStatusCodes": 'http://terminology.hl7.org/CodeSystem/condition-ver-status'
+codesystem "AllergyIntoleranceClinicalStatusCodes": 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical'
+codesystem "AllergyIntoleranceVerificationStatusCodes": 'http://terminology.hl7.org/CodeSystem/allergyintolerance-verification'
+codesystem "ConditionCategoryCodes": 'http://terminology.hl7.org/CodeSystem/condition-category'
+codesystem "ObservationCategoryCodes": 'http://terminology.hl7.org/CodeSystem/observation-category'
+
+valueset "Active Condition": 'http://fhir.org/guides/cqf/common/ValueSet/active-condition'
+valueset "Inactive Condition": 'http://fhir.org/guides/cqf/common/ValueSet/inactive-condition'
+
+code "Birthdate": '21112-8' from "LOINC" display 'Birth date'
+code "Dead": '419099009' from "SNOMEDCT" display 'Dead'
+code "ER": 'ER' from "RoleCode" display 'Emergency room'
+code "ICU": 'ICU' from "RoleCode" display 'Intensive care unit'
+code "Billing": 'billing' from "Diagnosis Role" display 'Billing'
+
+// Condition Clinical Status Codes - Consider value sets for these
+code "active": 'active' from "ConditionClinicalStatusCodes"
+code "recurrence": 'recurrence' from "ConditionClinicalStatusCodes"
+code "relapse": 'relapse' from "ConditionClinicalStatusCodes"
+code "inactive": 'inactive' from "ConditionClinicalStatusCodes"
+code "remission": 'remission' from "ConditionClinicalStatusCodes"
+code "resolved": 'resolved' from "ConditionClinicalStatusCodes"
+
+// Condition Verification Status Codes - Consider value sets for these
+code "unconfirmed": 'unconfirmed' from ConditionVerificationStatusCodes
+code "provisional": 'provisional' from ConditionVerificationStatusCodes
+code "differential": 'differential' from ConditionVerificationStatusCodes
+code "confirmed": 'confirmed' from ConditionVerificationStatusCodes
+code "refuted": 'refuted' from ConditionVerificationStatusCodes
+code "entered-in-error": 'entered-in-error' from ConditionVerificationStatusCodes
+
+code "allergy-active": 'active' from "AllergyIntoleranceClinicalStatusCodes"
+code "allergy-inactive": 'inactive' from "AllergyIntoleranceClinicalStatusCodes"
+code "allergy-resolved": 'resolved' from "AllergyIntoleranceClinicalStatusCodes"
+
+// Allergy/Intolerance Verification Status Codes - Consider value sets for these
+code "allergy-unconfirmed": 'unconfirmed' from AllergyIntoleranceVerificationStatusCodes
+code "allergy-confirmed": 'confirmed' from AllergyIntoleranceVerificationStatusCodes
+code "allergy-refuted": 'refuted' from AllergyIntoleranceVerificationStatusCodes
+
+// MedicationRequest Category Codes
+code "Community": 'community' from "MedicationRequestCategory" display 'Community'
+code "Discharge": 'discharge' from "MedicationRequestCategory" display 'Discharge'
+
+// Diagnosis Role Codes
+code "AD": 'AD' from "Diagnosis Role" display 'Admission diagnosis'
+code "DD": 'DD' from "Diagnosis Role" display 'Discharge diagnosis'
+code "CC": 'CC' from "Diagnosis Role" display 'Chief complaint'
+code "CM": 'CM' from "Diagnosis Role" display 'Comorbidity diagnosis'
+code "pre-op": 'pre-op' from "Diagnosis Role" display 'pre-op diagnosis'
+code "post-op": 'post-op' from "Diagnosis Role" display 'post-op diagnosis'
+code "billing": 'billing' from "Diagnosis Role" display 'billing diagnosis'
+
+// Observation Category Codes
+code "social-history": 'social-history' from "ObservationCategoryCodes" display 'Social History'
+code "vital-signs": 'vital-signs' from "ObservationCategoryCodes" display 'Vital Signs'
+code "imaging": 'imaging' from "ObservationCategoryCodes" display 'Imaging'
+code "laboratory": 'laboratory' from "ObservationCategoryCodes" display 'Laboratory'
+code "procedure": 'procedure' from "ObservationCategoryCodes" display 'Procedure'
+code "survey": 'survey' from "ObservationCategoryCodes" display 'Survey'
+code "exam": 'exam' from "ObservationCategoryCodes" display 'Exam'
+code "therapy": 'therapy' from "ObservationCategoryCodes" display 'Therapy'
+code "activity": 'activity' from "ObservationCategoryCodes" display 'Activity'
+
+// Condition Category Codes
+code "problem-list-item": 'problem-list-item' from "ConditionCategoryCodes" display 'Problem List Item'
+code "encounter-diagnosis": 'encounter-diagnosis' from "ConditionCategoryCodes" display 'Encounter Diagnosis'
+
+context Patient
+
+/*
+@description: Normalizes a value that is a choice of timing-valued types to an equivalent interval
+@comment: Normalizes a choice type of System.DateTime, System.Quantity, System.Interval<DateTime>, System.Interval<Quantity> types
+to an equivalent interval. This selection of choice types is a superset of the majority of choice types that are used as possible
+representations for timing-valued elements in QI-Core, allowing this function to be used across any resource.
+
+The input can be provided as a DateTime, Quantity, Interval<DateTime>, Interval<Quantity>.
+The intent of this function is to provide a clear and concise mechanism to treat single
+elements that have multiple possible representations as intervals so that logic doesn't have to account
+for the variability. More complex calculations (such as medication request period or dispense period
+calculation) need specific guidance and consideration. That guidance may make use of this function, but
+the focus of this function is on single element calculations where the semantics are unambiguous.
+If the input is a DateTime, the result a DateTime Interval beginning and ending on that dateTime.
+If the input is a Quantity, the result is a DateTime Interval beginning when the patient was the given Age,
+and ending immediately prior to when the patient was the given Age plus one year.
+If the input is a DateTime Interval, the result is a DateTime Interval.
+If the input is a Quantity Interval, the result is a DateTime Interval beginning when the patient was the Age given
+by the low end of the Interval, and ending immediately prior to when the patient was the Age given by the
+high end of the Interval plus one year.
+*/
+define function ToInterval(choice Choice<DateTime, Quantity, Interval<DateTime>, Interval<Quantity>>):
+  case
+	  when choice is DateTime then
+    	Interval[choice as DateTime, choice as DateTime]
+		when choice is Interval<DateTime> then
+  		choice as Interval<DateTime>
+		when choice is Quantity then
+		  Interval[Patient.birthDate + (choice as Quantity),
+			  Patient.birthDate + (choice as Quantity) + 1 year)
+		when choice is Interval<Quantity> then
+		  Interval[Patient.birthDate + (choice.low as Quantity),
+			  Patient.birthDate + (choice.high as Quantity) + 1 year)
+		else
+			null as Interval<DateTime>
+	end
+
+/*
+@description: Normalizes a value that is a choice of timing-valued types to an equivalent interval
+@comment: Normalizes a choice type of System.DateTime, System.Quantity, System.Interval<DateTime>, System.Interval<Quantity> types
+to an equivalent interval. This selection of choice types is a superset of the majority of choice types that are used as possible
+representations for timing-valued elements in QI-Core, allowing this function to be used across any resource.
+
+The input can be provided as a DateTime, Quantity, Interval<DateTime>, Interval<Quantity>.
+The intent of this function is to provide a clear and concise mechanism to treat single
+elements that have multiple possible representations as intervals so that logic doesn't have to account
+for the variability. More complex calculations (such as medication request period or dispense period
+calculation) need specific guidance and consideration. That guidance may make use of this function, but
+the focus of this function is on single element calculations where the semantics are unambiguous.
+If the input is a DateTime, the result a DateTime Interval beginning and ending on that dateTime.
+If the input is a Quantity, the result is a DateTime Interval beginning when the patient was the given Age,
+and ending immediately prior to when the patient was the given Age plus one year.
+If the input is a DateTime Interval, the result is a DateTime Interval.
+If the input is a Quantity Interval, the result is a DateTime Interval beginning when the patient was the Age given
+by the low end of the Interval, and ending immediately prior to when the patient was the Age given by the
+high end of the Interval plus one year.
+*/
+define fluent function toInterval(choice Choice<DateTime, Quantity, Interval<DateTime>, Interval<Quantity>>):
+  case
+	  when choice is DateTime then
+    	Interval[choice as DateTime, choice as DateTime]
+		when choice is Interval<DateTime> then
+  		choice as Interval<DateTime>
+		when choice is Quantity then
+		  Interval[Patient.birthDate + (choice as Quantity),
+			  Patient.birthDate + (choice as Quantity) + 1 year)
+		when choice is Interval<Quantity> then
+		  Interval[Patient.birthDate + (choice.low as Quantity),
+			  Patient.birthDate + (choice.high as Quantity) + 1 year)
+		else
+			null as Interval<DateTime>
+	end
+
+/*
+@description: Returns an interval representing the normalized Abatement of a given Condition resource.
+@comment: Normalizes a Condition's abatement, System.DateTime, System.Quantity, System.Interval<DateTime>, System.Interval<Quantity> types
+to an equivalent interval. This selection of choice types is a superset of the majority of choice types that are used as possible
+representations for timing-valued elements in QI-Core, allowing this function to be used across any resource.
+
+The input can be provided as a DateTime, Quantity, Interval<DateTime>, Interval<Quantity>.
+The intent of this function is to provide a clear and concise mechanism to treat single
+elements that have multiple possible representations as intervals so that logic doesn't have to account
+for the variability. More complex calculations (such as medication request period or dispense period
+calculation) need specific guidance and consideration. That guidance may make use of this function, but
+the focus of this function is on single element calculations where the semantics are unambiguous.
+If the input is a DateTime, the result a DateTime Interval beginning and ending on that dateTime.
+If the input is a Quantity, the result is a DateTime Interval beginning when the patient was the given Age,
+and ending immediately prior to when the patient was the given Age plus one year.
+If the input is a DateTime Interval, the result is a DateTime Interval.
+If the input is a Quantity Interval, the result is a DateTime Interval beginning when the patient was the Age given
+by the low end of the Interval, and ending immediately prior to when the patient was the Age given by the
+high end of the Interval plus one year.
+*/
+define function ToAbatementInterval(condition Condition):
+	if condition.abatement is DateTime then
+	  Interval[condition.abatement as DateTime, condition.abatement as DateTime]
+	else if condition.abatement is Quantity then
+		Interval[Patient.birthDate + (condition.abatement as Quantity),
+			Patient.birthDate + (condition.abatement as Quantity) + 1 year)
+	else if condition.abatement is Interval<Quantity> then
+	  Interval[Patient.birthDate + (condition.abatement.low as Quantity),
+		  Patient.birthDate + (condition.abatement.high as Quantity) + 1 year)
+	else if condition.abatement is Interval<DateTime> then
+	  Interval[condition.abatement.low, condition.abatement.high)
+	else null as Interval<DateTime>
+
+/*
+@description: Returns an interval representing the normalized Abatement of a given Condition resource.
+@comment: NOTE: Due to the complexity of determining an interval from a String, this function will throw
+a run-time exception if used with a Condition instance that has a String as the abatement value.
+*/
+define fluent function toAbatementInterval(condition Condition):
+	if condition.abatement is DateTime then
+	  Interval[condition.abatement as DateTime, condition.abatement as DateTime]
+	else if condition.abatement is Quantity then
+		Interval[Patient.birthDate + (condition.abatement as Quantity),
+			Patient.birthDate + (condition.abatement as Quantity) + 1 year)
+	else if condition.abatement is Interval<Quantity> then
+	  Interval[Patient.birthDate + (condition.abatement.low as Quantity),
+		  Patient.birthDate + (condition.abatement.high as Quantity) + 1 year)
+	else if condition.abatement is Interval<DateTime> then
+	  Interval[condition.abatement.low, condition.abatement.high)
+	else null as Interval<DateTime>
+
+/*
+@description: Returns an interval representing the normalized prevalence period of a given Condition resource.
+@comment: Uses the ToInterval and ToAbatementInterval functions to determine the widest potential interval from
+onset to abatement as specified in the given Condition.
+*/
+define function ToPrevalenceInterval(condition Condition):
+if condition.clinicalStatus ~ "active"
+  or condition.clinicalStatus ~ "recurrence"
+  or condition.clinicalStatus ~ "relapse" then
+  Interval[start of ToInterval(condition.onset), end of ToAbatementInterval(condition)]
+else
+  Interval[start of ToInterval(condition.onset), end of ToAbatementInterval(condition))
+
+/*
+@description: Returns an interval representing the normalized prevalence period of a given Condition resource.
+@comment: Uses the ToInterval and ToAbatementInterval functions to determine the widest potential interval from
+onset to abatement as specified in the given Condition.
+*/
+define fluent function toPrevalenceInterval(condition Condition):
+if condition.clinicalStatus ~ "active"
+  or condition.clinicalStatus ~ "recurrence"
+  or condition.clinicalStatus ~ "relapse" then
+  Interval[start of ToInterval(condition.onset), end of ToAbatementInterval(condition)]
+else
+  Interval[start of ToInterval(condition.onset), end of ToAbatementInterval(condition))
+
+/*
+Given an interval, return true if the interval has a starting boundary specified (i.e. the start of the interval is not null and not the minimum DateTime value)
+*/
+define function "HasStart"(period Interval<DateTime> ):
+  not ( start of period is null
+      or start of period = minimum DateTime
+  )
+
+/*
+Given an interval, return true if the interval has a starting boundary specified (i.e. the start of the interval is not null and not the minimum DateTime value)
+*/
+define fluent function hasStart(period Interval<DateTime> ):
+  not ( start of period is null
+      or start of period = minimum DateTime
+  )
+
+/*
+Given an interval, return true if the interval has an ending boundary specified (i.e. the end of the interval is not null and not the maximum DateTime value)
+*/
+define function "HasEnd"(period Interval<DateTime> ):
+  not (
+    end of period is null
+      or end of period = maximum DateTime
+  )
+
+/*
+Given an interval, return true if the interval has an ending boundary specified (i.e. the end of the interval is not null and not the maximum DateTime value)
+*/
+define fluent function hasEnd(period Interval<DateTime> ):
+  not (
+    end of period is null
+      or end of period = maximum DateTime
+  )
+
+/*
+Given an interval, return the ending point if the interval has an ending boundary specified, otherwise, return the starting point
+*/
+define function "Latest"(choice Choice<DateTime, Quantity, Interval<DateTime>, Interval<Quantity>> ):
+  (choice.toInterval()) period
+    return
+      if (HasEnd(period)) then end of period
+      else start of period
+
+/*
+Given an interval, return the ending point if the interval has an ending boundary specified, otherwise, return the starting point
+*/
+define fluent function latest(choice Choice<DateTime, Quantity, Interval<DateTime>, Interval<Quantity>> ):
+  (choice.toInterval()) period
+    return
+      if (HasEnd(period)) then end of period
+      else start of period
+
+/*
+Given an interval, return the starting point if the interval has a starting boundary specified, otherwise, return the ending point
+*/
+define function "Earliest"(choice Choice<DateTime, Quantity, Interval<DateTime>, Interval<Quantity>> ):
+  (choice.toInterval()) period
+    return
+      if (HasStart(period)) then start of period
+      else end of period
+
+/*
+Given an interval, return the starting point if the interval has a starting boundary specified, otherwise, return the ending point
+*/
+define fluent function earliest(choice Choice<DateTime, Quantity, Interval<DateTime>, Interval<Quantity>> ):
+  (choice.toInterval()) period
+    return
+      if (HasStart(period)) then start of period
+      else end of period
+
+/**
+ * Creates a list of integers from 1 to how many days are in the interval. Note, this wont create an index for
+ * the final day if it is less than 24 hours. This also includes the first 24 hour period.
+ */
+define function "Interval To Day Numbers"(Period Interval<DateTime>):
+  ( expand { Interval[1, duration in days between start of Period and end of Period]} ) DayNumber
+    return end of DayNumber
+
+/**
+ * Creates a list of integers from 1 to how many days are in the interval. Note, this wont create an index for
+ * the final day if it is less than 24 hours. This also includes the first 24 hour period.
+ */
+define fluent function toDayNumbers(Period Interval<DateTime>):
+  ( expand { Interval[1, duration in days between start of Period and end of Period]} ) DayNumber
+    return end of DayNumber
+
+/**
+ * Creates a list of 24 hour long intervals in an interval paired with the index (1 indexed) to which 24 hour interval it is.
+ * Note that the result will include intervals that are closed at the beginning and open at the end
+ */
+define function "Days In Period"(Period Interval<DateTime>):
+  ( "Interval To Day Numbers"(Period)) DayIndex
+    let startPeriod: start of Period + (24 hours * (DayIndex - 1)),
+    endPeriod: if (hours between startPeriod and end of Period < 24) then startPeriod
+      else start of Period + (24 hours * DayIndex)
+    return Tuple {
+      dayIndex: DayIndex,
+      dayPeriod: Interval[startPeriod, endPeriod)
+    }
+
+/**
+ * Creates a list of 24 hour long intervals in an interval paired with the index (1 indexed) to which 24 hour interval it is.
+ * Note that the result will include intervals that are closed at the beginning and open at the end
+ */
+define fluent function daysInPeriod(Period Interval<DateTime>):
+  ( "Interval To Day Numbers"(Period)) DayIndex
+    let startPeriod: start of Period + (24 hours * (DayIndex - 1)),
+    endPeriod: if (hours between startPeriod and end of Period < 24) then startPeriod
+      else start of Period + (24 hours * DayIndex)
+    return Tuple {
+      dayIndex: DayIndex,
+      dayPeriod: Interval[startPeriod, endPeriod)
+    }


### PR DESCRIPTION
This is a stab at defining a QICoreCommon library that is a repeat of FHIRCommon, but uses QICore. This workaround is needed to handle an existing issue related to QI-Core inheritance from FHIR. Per @brynrhodes, work is being done to update https://github.com/cqframework/clinical_quality_language. A QI-Core element is a FHIR element, so there shouldn't be a problem, but there is because of the way the models were flattened. Update to Translator would be to use derivation potentially. Until then, something is needed to bridge the gap. 
