### PR TITLE
Resolve InValueSet error

### DIFF
--- a/input/cql/AdvancedIllnessandFrailtyExclusionQICore4.cql
+++ b/input/cql/AdvancedIllnessandFrailtyExclusionQICore4.cql
@@ -76,8 +76,8 @@ define "Has Criteria Indicating Frailty":
       where QICoreCommon."ToInterval" ( FrailtyDeviceOrder.authoredOn ) during day of "Measurement Period"
   )
     or exists ( (Status."Final Survey Observation"([Observation: "Medical equipment used"])) FrailtyDeviceApplied
-        where //FrailtyDeviceApplied.value in "Frailty Device" and //InValueSet error per https://github.com/cqframework/vscode-cql/issues/16
-          QICoreCommon."ToInterval" ( FrailtyDeviceApplied.effective ) ends during day of "Measurement Period"
+        where FrailtyDeviceApplied.value as Concept in "Frailty Device"
+          and QICoreCommon."ToInterval" ( FrailtyDeviceApplied.effective ) ends during day of "Measurement Period"
     )
     or exists ( [Condition: "Frailty Diagnosis"] FrailtyDiagnosis
         where QICoreCommon."ToPrevalenceInterval" ( FrailtyDiagnosis ) overlaps "Measurement Period"


### PR DESCRIPTION
Update CQL to address InValueSet error resulting from ambiguity between possible Observation.value type choices (i.e., Concept, String). This is related to https://github.com/cqframework/vscode-cql/issues/16.